### PR TITLE
add collection sync

### DIFF
--- a/roles/aap/defaults/main.yml
+++ b/roles/aap/defaults/main.yml
@@ -39,3 +39,30 @@ lb2193_aap_caac_aap_collections_list:
  - "infra.ee_utilities:==4.0.0"
  - "infra.aap_configuration:==3.1.0"
  - "ansible.hub:==1.0.0"
+
+
+lb2193_hub_collection_remotes:
+  - name: community
+    url: https://galaxy.ansible.com/
+    requirements:
+      - name: infra.ee_utilities
+        version: ">=4.0.0"
+      - name: infra.aap_utilities
+        version: ">=2.5.2"
+      - name: containers.podman
+        version: ">=1.13.0"
+      - name: community.general
+        version: ">=10.4.0"
+      - name: infra.aap_configuration
+        version: ">=3.1.0"
+      - name: awx.awx
+
+
+lb2193_hub_collection_repositories:
+  - name: community
+    description: "description of community repository"
+    pulp_labels:
+      pipeline: "approved"
+    distribution:
+      state: present
+    remote: community

--- a/roles/aap/defaults/main.yml
+++ b/roles/aap/defaults/main.yml
@@ -41,7 +41,7 @@ lb2193_aap_caac_aap_collections_list:
  - "ansible.hub:==1.0.0"
 
 
-lb2193_hub_collection_remotes:
+lb2193_aap_caac_aap_hub_collection_remotes:
   - name: community
     url: https://galaxy.ansible.com/
     requirements:
@@ -58,7 +58,7 @@ lb2193_hub_collection_remotes:
       - name: awx.awx
 
 
-lb2193_hub_collection_repositories:
+lb2193_aap_caac_aap_hub_collection_repositories:
   - name: community
     description: "description of community repository"
     pulp_labels:

--- a/roles/aap/tasks/main.yml
+++ b/roles/aap/tasks/main.yml
@@ -33,3 +33,23 @@
   loop: "{{ lb2193_aap_caac_aap_collections_list }}"
   when: lb2193_aap_caac_aap_collections_list | length > 0
   ignore_errors: yes
+
+- name: Include collection remote role
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.hub_collection_remote
+  vars:
+    hub_collection_remotes: '{{ lb2193_hub_collection_remotes }}'
+
+- name: Include collection repository role
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.hub_collection_repository
+  vars:
+    hub_collection_repositories: '{{ lb2193_hub_collection_repositories }}'
+
+- name: Include collection repository role
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.hub_collection_repository_sync
+  vars:
+    hub_collection_repositories: '{{ lb2193_hub_collection_repositories }}'
+    hub_configuration_collection_repository_sync_async_delay: 5
+    hub_configuration_collection_repository_sync_async_retries: 150

--- a/roles/aap/tasks/main.yml
+++ b/roles/aap/tasks/main.yml
@@ -38,18 +38,18 @@
   ansible.builtin.include_role:
     name: infra.aap_configuration.hub_collection_remote
   vars:
-    hub_collection_remotes: '{{ lb2193_hub_collection_remotes }}'
+    hub_collection_remotes: '{{ lb2193_aap_caac_aap_hub_collection_remotes }}'
 
 - name: Include collection repository role
   ansible.builtin.include_role:
     name: infra.aap_configuration.hub_collection_repository
   vars:
-    hub_collection_repositories: '{{ lb2193_hub_collection_repositories }}'
+    hub_collection_repositories: '{{ lb2193_aap_caac_aap_hub_collection_repositories }}'
 
 - name: Include collection repository role
   ansible.builtin.include_role:
     name: infra.aap_configuration.hub_collection_repository_sync
   vars:
-    hub_collection_repositories: '{{ lb2193_hub_collection_repositories }}'
+    hub_collection_repositories: '{{ lb2193_aap_caac_aap_hub_collection_repositories }}'
     hub_configuration_collection_repository_sync_async_delay: 5
     hub_configuration_collection_repository_sync_async_retries: 150

--- a/roles/aap/tasks/main.yml
+++ b/roles/aap/tasks/main.yml
@@ -28,12 +28,6 @@
     single_branch: yes
     version: '{{ lb2193_aap_caac_aap_github_version }}'
 
-- name: Install specific Ansible collections
-  ansible.builtin.command: ansible-galaxy collection install {{ item }}
-  loop: "{{ lb2193_aap_caac_aap_collections_list }}"
-  when: lb2193_aap_caac_aap_collections_list | length > 0
-  ignore_errors: yes
-
 - name: Include collection remote role
   ansible.builtin.include_role:
     name: infra.aap_configuration.hub_collection_remote
@@ -53,3 +47,9 @@
     hub_collection_repositories: '{{ lb2193_aap_caac_aap_hub_collection_repositories }}'
     hub_configuration_collection_repository_sync_async_delay: 5
     hub_configuration_collection_repository_sync_async_retries: 150
+
+- name: Install specific Ansible collections
+  ansible.builtin.command: ansible-galaxy collection install {{ item }}
+  loop: "{{ lb2193_aap_caac_aap_collections_list }}"
+  when: lb2193_aap_caac_aap_collections_list | length > 0
+  ignore_errors: yes


### PR DESCRIPTION
Add in a collection sync, the ansible.hub and infra.aap_configuration should be available for lab builds from what I understand, and auth provided. 

Thanks.