### PR TITLE
revert nginx timeout to main nginx

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for nginx
 
 # Provide the path to the nginx configuration file.
-lb2193_aap_caac_nginx_conf_path : "/home/lab-user/aap/gateway/nginx/etc/nginx.conf"
+lb2193_aap_caac_nginx_conf_path : "/etc/nginx/nginx.conf"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Changing Nginx client max body size Value
   ansible.builtin.lineinfile:
     path: "{{ lb2193_aap_caac_nginx_conf_path }}"
-    regexp: '.*client_max_body_size 5m;'
-    line: '        client_max_body_size 100m;'
+    insertafter: '    keepalive_timeout   65;'
+    line: '    client_max_body_size 200m;'
   become: true
   notify: Reload Nginx


### PR DESCRIPTION
revert nginx timeout to main nginx
Found that the gateway one was not taking, retested and reverted back to this.