### PR TITLE
remove preprovided auth info

### DIFF
--- a/roles/aap/tasks/main.yml
+++ b/roles/aap/tasks/main.yml
@@ -82,24 +82,6 @@
     path: "{{ lb2193_aap_caac_aap_ansible_cfg_path }}/group_vars/all/auth.yml"
     block: |
       aap_hostname: "{{ lb2193_aap_caac_aap_hostname | regex_replace('^https://', '') }}"
-      aap_username: "{{ lb2193_aap_caac_aap_username }}"
-      aap_password: "{{ lb2193_aap_caac_aap_password }}"
-      aap_validate_certs: false
-      aap_request_timeout: 60
-      
-      ee_pull_collections_from_hub: false
-      aap_service_account_username: aap_service_account
-
-      ee_registry_username: "{{ lb2193_aap_caac_aap_username }} "
-      ee_registry_password: "{{ lb2193_aap_caac_aap_password }}"
-
-      ee_registry_dest: "{{ lb2193_aap_caac_aap_hostname | regex_replace('^https://', '') }}/config"
-      ee_base_registry: "{{ lb2193_aap_caac_aap_hostname | regex_replace('^https://', '') }}"
-      
-      ee_base_registry_username: "{{ lb2193_aap_caac_aap_username }}"
-      ee_base_registry_password: "{{ lb2193_aap_caac_aap_password }}"
-      
-      ee_validate_certs: false
     marker: "# {mark} ANSIBLE MANAGED Variable configuration"
   
 - name: configure Vautl.yml file


### PR DESCRIPTION
As discussed previously, we want the user to put these in on their own, by design, please stop adding this in, this the 2nd time we've had to remove it. 